### PR TITLE
Fixed issue when navigating to duplicate route

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -181,7 +181,26 @@
       transitionAnimationEnd(router.previousRoute);
     }
     if (router.activeRoute) {
-      router.activeRoute.removeAttribute('active');
+      // If the route we're navigating to references the same object that the current route is set to,
+      // for example when changing a databound parameter (ex: navigating from article/0 to articles/1),
+      // check if the route has a navigation-action modifier set and perform the appropriate action.
+      if (route.hasAttribute('import')
+          && router.activeRoute.hasAttribute('import')
+          && route.hasAttribute('navigate-action')
+          && (route.getAttribute('import') == router.activeRoute.getAttribute('import'))) {
+
+          var action = route.getAttribute('navigate-action');
+
+          if (action == 'removeDuplicateInstance') {
+              transitionAnimationEnd(router.activeRoute);
+          } else if (action == 'stopOnDuplicateLoad') {
+              return;
+          } else {
+              fire('navigate-action-not-found', eventDetail, router)
+          }
+      } else {
+          router.activeRoute.removeAttribute('active');
+      }
     }
     router.previousRoute = router.activeRoute;
     router.activeRoute = route;


### PR DESCRIPTION
When navigating to a duplicate route (possibly with different databound parameters) after navigating to a second route, the app-router would load two instances of the component within the route. This lead to various weirdness. To correct that, I added a "navigate-action" attribute to the routes that I wanted something extra to be done with when they load. If the navigate-action value is set to "removeDuplicateInstance" and the route we're navigating to references the same component as the active route, the "transitionAnimationEnd" will be called with the active route, effectively removing it from the DOM the same as if an animation was still in progress, and the new instance of the component will continue to be loaded like normal. If "stopOnDuplicateLoad" is the navigate-action instead, the call will return, which should stop any further loading and not recreate the component in the DOM.

Example: Previously when navigating to http://example.com/appPageAlpha/1, then to http://example.com/appPageBeta/1, and then to http://example.com/appPageBeta/2, the appPageBeta component would be loaded in the DOM twice. When Navigating to appPageBeta a third time, the component would be cleaned out properly because the 'transitionAnimationInProgress' would still be true, since the core-animated-pages component didn't navigate to a new page (because the path attribute between each of those routes is identical), and the animation never occurred.
