### PR TITLE
change to enable model update

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -279,7 +279,7 @@
     eventDetail.model = model;
     fire('before-data-binding', eventDetail, router);
     fire('before-data-binding', eventDetail, eventDetail.route);
-    return model;
+    return eventDetail.model;
   }
 
   // Replace the active route's content with the new element


### PR DESCRIPTION
Hi,

I corrected a bug, where when you change a model in the "before-data-binding" event it would always return the previous model.

Please, take a look.

Thanks!
