### PR TITLE
Use Polymer import instead of creating link tags manually

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -334,6 +334,10 @@
       scrollToHash(url.hash);
     }
 
+    if(element){
+      element.init()
+    }
+
     fire('activate-route-end', eventDetail, router);
     fire('activate-route-end', eventDetail, eventDetail.route);
   }

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -240,27 +240,14 @@
   function importAndActivate(router, importUri, route, url, eventDetail) {
     var importLink;
     function importLoadedCallback() {
+      importedURIs[importUri] = true;
       activateImport(router, importLink, importUri, route, url, eventDetail);
     }
 
     if (!importedURIs.hasOwnProperty(importUri)) {
-      // hasn't been imported yet
-      importedURIs[importUri] = true;
-      importLink = document.createElement('link');
-      importLink.setAttribute('rel', 'import');
-      importLink.setAttribute('href', importUri);
-      importLink.addEventListener('load', importLoadedCallback);
-      document.head.appendChild(importLink);
-    } else {
-      // previously imported. this is an async operation and may not be complete yet.
-      importLink = document.querySelector('link[href="' + importUri + '"]');
-      if (importLink.import) {
-        // import complete
-        importLoadedCallback();
-      } else {
-        // wait for `onload`
-        importLink.addEventListener('load', importLoadedCallback);
-      }
+      Polymer.import( [importUri], importLoadedCallback)
+    }else {
+      importLoadedCallback()
     }
   }
 


### PR DESCRIPTION
Polymer has an import module which will allow you to cleanly import polymer elements, rather than having to manually creating link tags. 

Also, the current approach behaves erratically, especially in Firefox. For instance, in Firefox the values that I'm passing to the router url is not automatically bounded at the time the element is created. I'm assuming that this issue is caused due to the time delay while calling the importLoadedCallBack. This issue also fixed by using Polymer.import. 

I've tested this scenario in both Firefox and Chrome. Please  check and let me know incase you need something from me. 