### PR TITLE
Skip activating new route if the current route will not change

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -209,6 +209,17 @@
       return;
     }
 
+    // Update model instead of re-rendering if we're on the same route
+    if (router.activeRoute && router.activeRoute === route && route.firstElementChild) {
+      var model = createModel(router, route, url, eventDetail);
+      for (var property in model) {
+        if (model.hasOwnProperty(property)) {
+          route.firstElementChild[property] = model[property];
+        }
+      }
+      return;
+    }
+
     // update the references to the activeRoute and previousRoute. if you switch between routes quickly you may go to a
     // new route before the previous route's transition animation has completed. if that's the case we need to remove
     // the previous route's content before we replace the reference to the previous route.


### PR DESCRIPTION
This avoids reloading and re-rendering unnecessarily.  This is particularly
useful if you have nested routers where the inner router handles lower url
segments and the wrapper handles upper fragments, ie:

```html
<app-router id="outer">
 <app-route path="/" template="/home-page.html"></app-route>
 <app-route path="/user/*" template="/user-page.html"></app-route>
</app-router>
```

user-page.html:

```html
<app-router id="inner">
 <app-route path="/user/profile" template="/user-profile.html"></app-route>
 <app-route path="/user/stats" template="/user-stats.html"></app-route>
</app-router>
```

Without this change, navigating between user pages will cause the
`outer` route to activate, followed by the `inner` route.  With this change,
navigating between user pages will only trigger the `inner` routes, and skip
re-rendering the containing `user-page.html`.