### PR TITLE
Allow a trailing wildcard to match when the final url segment is missing

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -508,8 +508,8 @@
     // example routePathSegments = ['', 'example', '*']
     var routePathSegments = routePath.split('/');
 
-    // there must be the same number of path segments or it isn't a match
-    if (urlPathSegments.length !== routePathSegments.length) {
+    // there must be the same number of path segments or it isn't a match, unless the last segment is a wildcard, and length of remaining segments matches
+    if (urlPathSegments.length !== routePathSegments.length && (routePathSegments[routePathSegments.length-1] === '*' && urlPathSegments.length !== routePathSegments.length-1)) {
       return false;
     }
 
@@ -520,6 +520,10 @@
       if (routeSegment !== urlPathSegments[i] && routeSegment !== '*' && routeSegment.charAt(0) !== ':') {
         // the path segment wasn't the same string and it wasn't a wildcard or parameter
         return false;
+      }
+      if (i+1 === routePathSegments.length && urlPathSegments.length < routePathSegments.length && routePathSegments[i+1] === '*') {
+        // the next route segment is a wildcard, and we've matched all provided url segments
+        return true
       }
     }
 

--- a/tests/spec/routerSpec.js
+++ b/tests/spec/routerSpec.js
@@ -176,6 +176,10 @@ describe('testRoute(routePath, urlPath, trailingSlashOption, isRegExp)', functio
     expect(router.util.testRoute('/example/*', '/example/path', 'strict', false)).toEqual(true);
   });
 
+  it('should return true when matching with a trailing wildcard with missing last url segment', function() {
+    expect(router.util.testRoute('/example/*', '/example', 'strict', false)).toEqual(true);
+  });
+
   it('should return true when matching with a path argument', function() {
     expect(router.util.testRoute('/:patharg/path', '/example/path', 'strict', false)).toEqual(true);
   });


### PR DESCRIPTION
This allows you to define a route like:

```html
<app-router>
 <app-route path="/user/*" template="/user-page.html"></app-route>
</app-router>
```

And have it match `/user` in addition to `/user/sub`.

In combination with #67, you can then do sane nested routing without redraws
of the whole layout.