### PR TITLE
Make routes maintain references to their HTML imports

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -259,6 +259,7 @@
         activateImport(router, importLink, importUri, route, url, eventDetail);
       }
     }
+    route.importLink = importLink;
   }
 
   // Activate the imported custom element or template


### PR DESCRIPTION
    
This allows access to the HTML import during route events,
which would allow things like registering script callbacks
for templates as described in #81

Also this would allow for "unimporting" the route HTML import
from a route context, also mentioned in #81