### PR TITLE
Template params

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -278,21 +278,12 @@
     }
   }
 
-  // Override/assign any element properties with properties from model
-  function injectModelProperties(element, model) {
-    for (var property in model) {
-      if (model.hasOwnProperty(property)) {
-        element[property] = model[property];
-      }
-    }
-  }
-
   // Data bind the custom element then activate it
   function activateCustomElement(router, elementName, route, url, eventDetail) {
     var customElement = document.createElement(elementName),
       model = createModel(router, route, url, eventDetail);
 
-    injectModelProperties(customElement, model);
+    customElement.params = model.params;
     activateElement(router, customElement, url, eventDetail);
   }
 
@@ -302,7 +293,7 @@
     if (template.getAttribute('is') === 'auto-binding') {
       var model = createModel(router, route, url, eventDetail);
       templateInstance = document.importNode(template, true);
-      injectModelProperties(templateInstance, model);
+      templateInstance.params = model.params;
     } else if ('createInstance' in template) {
       // template.createInstance(model) is a Polymer method that binds a model to a template and also fixes
       // https://github.com/erikringsmuth/app-router/issues/19
@@ -316,7 +307,9 @@
 
   // Create the route's model
   function createModel(router, route, url, eventDetail) {
-    var model = utilities.routeArguments(route.getAttribute('path'), url.path, url.search, route.hasAttribute('regex'), router.getAttribute('typecast') === 'auto');
+    var model = {
+      params: utilities.routeArguments(route.getAttribute('path'), url.path, url.search, route.hasAttribute('regex'), router.getAttribute('typecast') === 'auto')
+    };
     if (route.hasAttribute('bindRouter') || router.hasAttribute('bindRouter')) {
       model.router = router;
     }

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -298,8 +298,8 @@
     var templateInstance;
     if (template.getAttribute('is') === 'auto-binding') {
       var model = createModel(router, route, url, eventDetail);
-      injectModelProperties(template, model);
-      templateInstance = template;
+      templateInstance = document.importNode(template, true);
+      injectModelProperties(templateInstance, model);
     } else if ('createInstance' in template) {
       // template.createInstance(model) is a Polymer method that binds a model to a template and also fixes
       // https://github.com/erikringsmuth/app-router/issues/19

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -275,22 +275,32 @@
     }
   }
 
-  // Data bind the custom element then activate it
-  function activateCustomElement(router, elementName, route, url, eventDetail) {
-    var customElement = document.createElement(elementName);
-    var model = createModel(router, route, url, eventDetail);
+  // Override/assign any element properties with properties from model
+  function injectModelProperties(element, model) {
     for (var property in model) {
       if (model.hasOwnProperty(property)) {
-        customElement[property] = model[property];
+        element[property] = model[property];
       }
     }
+  }
+
+  // Data bind the custom element then activate it
+  function activateCustomElement(router, elementName, route, url, eventDetail) {
+    var customElement = document.createElement(elementName),
+      model = createModel(router, route, url, eventDetail);
+
+    injectModelProperties(customElement, model);
     activateElement(router, customElement, url, eventDetail);
   }
 
   // Create an instance of the template
   function activateTemplate(router, template, route, url, eventDetail) {
     var templateInstance;
-    if ('createInstance' in template) {
+    if (template.getAttribute('is') === 'auto-binding') {
+      var model = createModel(router, route, url, eventDetail);
+      injectModelProperties(template, model);
+      templateInstance = template;
+    } else if ('createInstance' in template) {
       // template.createInstance(model) is a Polymer method that binds a model to a template and also fixes
       // https://github.com/erikringsmuth/app-router/issues/19
       var model = createModel(router, route, url, eventDetail);


### PR DESCRIPTION
Improvements:
- An extensible model for future purposes
- More declarative/self-documenting templates
( {{ params.id }} instead of just {{ id }} )
- Future support for nested template parameter bindings
( <template bind> seems to need an object to bind, not strings?)
- Reduces code and drops the property assignment loop (injectModelProperties)
- Prevents the behavior that any query parameter can override HTMLElement properties
    such as ?id=mynewid or hiding one/many elements/layouts with ?hidden=true

As discussed in #81