### PR TITLE
Fire 'template-not-found' event on route and router when template is null

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -318,6 +318,11 @@
 
   // Create an instance of the template
   function activateTemplate(router, template, route, url, eventDetail) {
+    if (template === null) {
+      fire('template-not-found', eventDetail, router);
+      fire('template-not-found', eventDetail, route);
+      return;
+    }
     var templateInstance;
     if ('createInstance' in template) {
       // template.createInstance(model) is a Polymer method that binds a model to a template and also fixes


### PR DESCRIPTION
If the HTML import succeeds but the expected template can't be found (no template
tag or wrong template ID), app router currently errors out with:
`Uncaught TypeError: Cannot use 'in' operator to search for 'createInstance' in null`

This commit prevents that error and instead fires a `template-not-found` event.
