### PR TITLE
Add hashbang support to go() by introducing the "hashbang" mode to app-router

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -5,7 +5,7 @@
   var isIE = 'ActiveXObject' in window;
   var previousUrl = {};
 
-  // <app-router [init="auto|manual"] [mode="auto|hash|pushstate"] [trailingSlash="strict|ignore"] [typecast="auto|string"] [bindRouter]></app-router>
+  // <app-router [init="auto|manual"] [mode="auto|hash|hashbang|pushstate"] [trailingSlash="strict|ignore"] [typecast="auto|string"] [bindRouter]></app-router>
   var AppRouter = Object.create(HTMLElement.prototype);
   AppRouter.util = utilities;
 
@@ -35,7 +35,7 @@
       router.setAttribute('trailingSlash', 'strict');
     }
 
-    // mode="auto|hash|pushstate"
+    // mode="auto|hash|hashbang|pushstate"
     if (!router.hasAttribute('mode')) {
       router.setAttribute('mode', 'auto');
     }
@@ -115,8 +115,12 @@
   // }
   AppRouter.go = function(path, options) {
     if (this.getAttribute('mode') !== 'pushstate') {
-      // mode == auto or hash
-      path = '#' + path;
+      // mode == auto, hash or hashbang
+      if (this.getAttribute('mode') === 'hashbang') {
+        path = '#!' + path;
+      } else {
+        path = '#' + path;
+      }
     }
     if (options && options.replace === true) {
       window.history.replaceState(null, null, path);


### PR DESCRIPTION
app-router already supports hash changes with hashbang URLs but not when navigating.
This commit will make .go() prefix paths with "#!" instead of "#" if app-router has the 
attribute mode="hashbang".