### PR TITLE
Update previous url when only hash changed

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -189,6 +189,7 @@
     // don't load a new route if only the hash fragment changed
     if (url.hash !== previousUrl.hash && url.path === previousUrl.path && url.search === previousUrl.search && url.isHashPath === previousUrl.isHashPath) {
       scrollToHash(url.hash);
+      previousUrl = url;
       return;
     }
     previousUrl = url;


### PR DESCRIPTION
When only hash changed (example: from '#hash1' to '#hash2'), previous url didn't update. And when we again changed hash to '#hash1', we have behaviour such as we changed not only hash, because condition url.hash !== previousUrl.hash isn't true (we have: url.hash ==  '#hash1'  and previousUrl.hash == '#hash1').