### PR TITLE
Add HTML import error callback

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -293,6 +293,8 @@
       var errorDetail = {
         errorEvent: event,
         importUri: importUri,
+        route: route,
+        url: url,
         routeDetail: eventDetail
       };
       fire('import-error', errorDetail, router);


### PR DESCRIPTION
As it is  described in the spec, there can be thrown an error event when HTMl import was failed: 
```
The link element fires a simple event called load for successful loading attempt. 
For failed attempt, it fires a simple event named error.
```

I created this PR to catch 404 errors when performing import. My point is that `app-router` should itself fire an event containing URL of requested `<link>` resource.

@erikringsmuth @jmalonzo PTAL.

See also #101 