### PR TITLE
Do not use /deep/ selector when using Polymer 1.x Shady DOM mode

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -461,7 +461,15 @@
     // it will scroll to the top of the page. let the browser finish the current event loop and scroll to the top of the page
     // before we scroll to the element with id or name `middle`.
     setTimeout(function() {
-      var hashElement = document.querySelector('html /deep/ ' + hash) || document.querySelector('html /deep/ [name="' + hash.substring(1) + '"]');
+      var hashElement;
+      try {
+        hashElement = document.querySelector('html /deep/ ' + hash) || document.querySelector('html /deep/ [name="' + hash.substring(1) + '"]');
+      } catch (e) {
+        // DOM exception 12 (unknown selector) is thrown in Safari when using Polymer 1.x Shady DOM mode
+        if (window.Polymer && window.Polymer.Settings && window.Polymer.Settings.dom === 'shady') {
+          hashElement = document.querySelector(hash) || document.querySelector('[name="' + hash.substring(1) + '"]');
+        }
+      }
       if (hashElement && hashElement.scrollIntoView) {
         hashElement.scrollIntoView(true);
       }

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -465,10 +465,8 @@
       try {
         hashElement = document.querySelector('html /deep/ ' + hash) || document.querySelector('html /deep/ [name="' + hash.substring(1) + '"]');
       } catch (e) {
-        // DOM exception 12 (unknown selector) is thrown in Safari when using Polymer 1.x Shady DOM mode
-        if (window.Polymer && window.Polymer.Settings && window.Polymer.Settings.dom === 'shady') {
-          hashElement = document.querySelector(hash) || document.querySelector('[name="' + hash.substring(1) + '"]');
-        }
+        // DOM exception 12 (unknown selector) is thrown in Firefox, Safari etc. when using Polymer 1.x Shady DOM mode
+        hashElement = document.querySelector(hash) || document.querySelector('[name="' + hash.substring(1) + '"]');
       }
       if (hashElement && hashElement.scrollIntoView) {
         hashElement.scrollIntoView(true);


### PR DESCRIPTION
A bugfix for Polymer 1.x users with Shady DOM mode (enabled by default). Fixes #154
@jmalonzo PTAL